### PR TITLE
removes unused dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,9 +16,6 @@
     "lodash": "3.10.0",
     "fontawesome": "~4.5.0",
     "qunit": "1.20.0",
-    "spinjs": "2.0.2",
-    "modernizr": "2.8.3",
-    "tooltipster": "3.3.0",
     "trackpad-scroll-emulator": "1.0.8"
   },
   "resolutions": {


### PR DESCRIPTION
This PR removes a few unused bower dependencies. I couldn't find any mention of them and ultimately, things like tooltips and loading icons can be composed within the blocks provided.
