### PR TITLE
removes unused ember-component-inbound-actions addon

### DIFF
--- a/addon/components/as-calendar.js
+++ b/addon/components/as-calendar.js
@@ -1,9 +1,8 @@
 import jstz from 'jstz';
 import Ember from 'ember';
 import ComponentCalendar from 'ember-calendar/models/component-calendar';
-import InboundActionsMixin from 'ember-component-inbound-actions/inbound-actions';
 
-export default Ember.Component.extend(InboundActionsMixin, {
+export default Ember.Component.extend({
   classNameBindings: [':as-calendar'],
   tagName: 'section',
 

--- a/blueprints/ember-calendar/index.js
+++ b/blueprints/ember-calendar/index.js
@@ -12,7 +12,6 @@ module.exports = {
     }).then(function() {
       return self.addPackagesToProject([
         { name: 'ember-cli-sass', target: '5.3.1' },
-        { name: 'ember-component-inbound-actions', target: '0.0.4' },
         { name: 'ember-rl-dropdown', target: '0.7.0' },
         { name: 'liquid-fire', target: '0.21.3' }
       ]);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "ember-cli-sass": "5.3.1",
     "ember-cli-sri": "1.2.0",
     "ember-cli-uglify": "1.2.0",
-    "ember-component-inbound-actions": "0.0.4",
     "ember-data": "2.1.0",
     "ember-disable-proxy-controllers": "1.0.1",
     "ember-export-application-global": "1.0.5",


### PR DESCRIPTION
This dependency is unused. It appears to be a relic from when they were not using DDAU
