### PR TITLE
pass navigation info when changing view (fixes #17)

### DIFF
--- a/addon/components/as-calendar/header.js
+++ b/addon/components/as-calendar/header.js
@@ -13,14 +13,24 @@ export default Ember.Component.extend({
       this.get('model').navigateNext();
 
       if (this.attrs['onNavigate']) {
-        this.attrs['onNavigate'](1);
+        this.attrs['onNavigate']({
+          view: this.get('model.type'),
+          start: this.get('model.startDate'),
+          end: this.get('model.endDate'),
+          dir: 1
+        });
       }
     },
     navigatePrevious: function() {
       this.get('model').navigatePrevious();
 
       if (this.attrs['onNavigate']) {
-        this.attrs['onNavigate'](-1);
+        this.attrs['onNavigate']({
+          view: this.get('model.type'),
+          start: this.get('model.startDate'),
+          end: this.get('model.endDate'),
+          dir: -1
+        });
       }
     },
 

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -47,6 +47,10 @@ export default Ember.Controller.extend({
       console.log('Edit', occurrence);
     },
 
+    calendarNavigate(props) {
+      console.log(props);
+    },
+
     onStartTimeSelected(time) {
       this.set('selectedStartingTime', time);
     },

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -55,6 +55,7 @@
   dayStartingTime=dayStartingTime
   dayEndingTime=dayEndingTime
   timeSlotDuration="00:30"
+  onNavigate=(action "calendarNavigate")
   onAddOccurrence=(action "calendarAddOccurrence")
   onUpdateOccurrence=(action "calendarUpdateOccurrence")
   onEditOccurrence=(action "calendarEditOccurrence")


### PR DESCRIPTION
This PR resolves #17.

Rather than just passing a number to indicate the direction of the navigation change, it now returns an object containing the view type, start date, end date and direction. 

This will allow for things like lazy loading of data on view change, caching, etc.
