### PR TITLE
add class to "show more" link

### DIFF
--- a/app/templates/components/as-calendar.hbs
+++ b/app/templates/components/as-calendar.hbs
@@ -39,7 +39,7 @@
         </li>
       {{/each}}
       {{#if day.hasShowMore}}
-        <a href {{action 'navigateToDay' day.value bubbles=false}}>+{{day.showMoreCount}} more</a>
+        <a class="as-calendar-timetable__day-showmore" href {{action 'navigateToDay' day.value bubbles=false}}>+{{day.showMoreCount}} more</a>
       {{/if}}
     {{else}}
       {{#each day.occurrences as |occurrence|}}


### PR DESCRIPTION
This is a small PR that adds a class to the "show more" link that displays in the calendar view when there are more than a few events in a day. The purpose is simply to allow for a target to style.
