### PR TITLE
fixes the position of time labels (fixes #28)

### DIFF
--- a/addon/components/as-calendar/timetable.js
+++ b/addon/components/as-calendar/timetable.js
@@ -82,7 +82,8 @@ export default Ember.Component.extend({
   timeSlotLabelListStyle: Ember.computed('timeSlotHeight', function() {
     var timeSlotHeight = this.get('timeSlotHeight');
 
-    return Ember.String.htmlSafe(`line-height: ${timeSlotHeight * 2}px;`);
+    return (`margin-top: -${timeSlotHeight}px;
+             line-height: ${timeSlotHeight * 2}px;`).htmlSafe();
   }),
 
   timeSlotLabelStyle: Ember.computed('timeSlotHeight', function() {

--- a/addon/components/as-calendar/timetable.js
+++ b/addon/components/as-calendar/timetable.js
@@ -82,7 +82,7 @@ export default Ember.Component.extend({
   timeSlotLabelListStyle: Ember.computed('timeSlotHeight', function() {
     var timeSlotHeight = this.get('timeSlotHeight');
 
-    return (`margin-top: -${timeSlotHeight}px;
+    return (`margin-top: -${timeSlotHeight / 2}px;
              line-height: ${timeSlotHeight * 2}px;`).htmlSafe();
   }),
 

--- a/addon/components/as-calendar/timetable.js
+++ b/addon/components/as-calendar/timetable.js
@@ -82,8 +82,7 @@ export default Ember.Component.extend({
   timeSlotLabelListStyle: Ember.computed('timeSlotHeight', function() {
     var timeSlotHeight = this.get('timeSlotHeight');
 
-    return (`margin-top: -${timeSlotHeight / 2}px;
-             line-height: ${timeSlotHeight * 2}px;`).htmlSafe();
+    return Ember.String.htmlSafe(`margin-top: -${timeSlotHeight / 2}px; line-height: ${timeSlotHeight * 2}px;`);
   }),
 
   timeSlotLabelStyle: Ember.computed('timeSlotHeight', function() {


### PR DESCRIPTION
This restores a piece of the original code that offsets the time labels by -20px. 

I'm not sure if this was intentional as part of the development of the time slot indicator that appears on hover, but the current position is not correct.
